### PR TITLE
Fix stale links in example notebooks

### DIFF
--- a/01_eccov4.ipynb
+++ b/01_eccov4.ipynb
@@ -36,7 +36,7 @@
     "If you're curious, here are some resources to learn more about zarr:\n",
     "  - https://zarr.readthedocs.io/en/stable/tutorial.html\n",
     "  - https://speakerdeck.com/rabernat/pangeo-zarr-cloud-data-storage\n",
-    "  - https://mrocklin.github.com/blog/work/2018/02/06/hdf-in-the-cloud\n",
+    "  - https://matthewrocklin.com/blog/work/2018/02/06/hdf-in-the-cloud\n",
     "\n",
     "The ECCO zarr data currently lives in [Google Cloud Storage](https://cloud.google.com/storage/) as part of the [Pangeo Data Catalog](http://catalog.pangeo.io/). This means we can open the whole dataset using one line of code.\n",
     "\n",
@@ -8558,7 +8558,7 @@
     "\n",
     "Xgcm allows us to create a `Grid` object, which understands how to interpolate and take differences in a way that is compatible with finite volume models such at MITgcm. Xgcm also works with many other models, including ROMS, POP, MOM5/6, NEMO, etc.\n",
     "\n",
-    "A second reason this is hard is because of the complex topology connecting the different MITgcm faces. Fortunately xgcm also [supports this](https://xgcm.readthedocs.io/en/latest/grid_topology.html)."
+    "A second reason this is hard is because of the complex topology connecting the different MITgcm faces. Fortunately xgcm also [supports this](https://xgcm.readthedocs.io/en/latest/grid_topology/)."
    ]
   },
   {

--- a/Readme.md
+++ b/Readme.md
@@ -32,4 +32,4 @@ After adding or changing a notebook, execute it end-to-end and commit it with
 its outputs so the documentation renders correctly.
 
 For more on setting up a development environment, see the
-[xgcm contributor guide](https://xgcm.readthedocs.io/en/latest/contributor_guide.html).
+[xgcm contributor guide](https://xgcm.readthedocs.io/en/latest/contributor_guide/).


### PR DESCRIPTION
Audited all notebooks (`*.ipynb`) and `Readme.md` for stale/broken links and fixed three confirmed-broken references (each verified by fetching old vs. new URL).

| File | Context | Old (status) | New (status) |
|------|---------|--------------|--------------|
| `01_eccov4.ipynb` | "supports this" link, heat-budget cell | `…/en/latest/grid_topology.html` (404) | `…/en/latest/grid_topology/` (200) |
| `01_eccov4.ipynb` | zarr resources list | `https://mrocklin.github.com/blog/work/2018/02/06/hdf-in-the-cloud` (connection refused) | `https://matthewrocklin.com/blog/work/2018/02/06/hdf-in-the-cloud` (200) |
| `Readme.md` | contributor-guide link | `…/en/latest/contributor_guide.html` (404) | `…/en/latest/contributor_guide/` (200) |

The xgcm docs migrated from Sphinx (`*.html`) to mkdocs-material (directory-style URLs), so the old `.html` paths now 404. The `mrocklin.github.com` host no longer resolves; the blog moved to `matthewrocklin.com` (the `mrocklin.github.io` redirect points there too).

Edits are confined to the changed URL strings; notebook outputs, `execution_count`, and metadata are untouched and the notebook remains valid JSON.

Left unchanged (verified still resolving): `http://xgcm.readthedocs.org` (302 → readthedocs.io), `gallery.pangeo.io/...04_eccov4.html` (200), `catalog.pangeo.io` (200), `mitgcm.org/...node50.html` (200), `github.com/xecco/gcmplots` (200), and the various Zenodo dataset links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)